### PR TITLE
Correctly colour the spanning tree in the LDM

### DIFF
--- a/src/Partition.elm
+++ b/src/Partition.elm
@@ -215,7 +215,7 @@ levelSplit : List (Graph.NodeContext n e) -> Int -> ( List n, List n ) -> ( List
 levelSplit paths distance acc =
     case paths of
         [] ->
-            ( [], [] )
+            empty
 
         ctx :: _ ->
             let


### PR DESCRIPTION
Closes #5 by implementing the spanning tree, then colouring based on a breadth-first traversal, partitioning on level depth from the root.

Before:
```elm
largestDifference [2,5,6,7,8,2,3,5] |> sumOfSets == (26,12)
```
Now:
```elm
largestDifference [2,5,6,7,8,2,3,5] |> sumOfSets == (19,19)
```